### PR TITLE
GitHub Actions workflow for building wheels

### DIFF
--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -65,7 +65,6 @@ jobs:
           python -m pip install -U pip wheel setuptools cibuildwheel
 
       - name: Build wheels
-        shell: bash
         env:
           # Build targeting
           CIBW_BUILD: ${{ matrix.target.cibw-build }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -77,6 +77,9 @@ jobs:
           CIBW_BEFORE_BUILD: python -m pip install -U pip -r requirements-dev.txt
           CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBOPUS_STATIC=1'
 
+          # Make macOS cross builds work by directing to system python
+          PYO3_CROSS_LIB_DIR: /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib
+
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -60,6 +60,12 @@ jobs:
         with:
           perl-version: '5.34'
 
+      - name: Install automake on macOS
+        shell: bash
+        if: matrix.target.os == 'macos-latest'
+        run: |
+          brew install automake
+
       - name: Install Python dependencies
         shell: bash
         run: |

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -20,6 +20,8 @@ jobs:
           - { os: 'windows-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'pc-windows-msvc', cibw-build: '*-win_amd64' }
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_i686' }
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_x86_64' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-musl', cibw-build: '*-musllinux_i686' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', cibw-build: '*-musllinux_x86_64' }
           - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', cibw-build: '*-macosx_x86_64' }
 
     name: Build wheels for ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}
@@ -30,10 +32,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install and set up CPython 3.9
+      - name: Install and set up CPython 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.x
           architecture: ${{ matrix.target.python-architecture }}
 
       - name: Install Rust toolchain with support for ${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
@@ -61,13 +63,9 @@ jobs:
       - name: Build wheels
         shell: bash
         env:
-          # Images
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
-
           # Build targeting
           CIBW_BUILD: ${{ matrix.target.cibw-build }}
-          CIBW_SKIP: cp2?-* cp35-* pp*
+          CIBW_SKIP: cp2?-* cp35-* cp36-* cp37-* pp*
 
           # Build process
           CIBW_BEFORE_ALL_LINUX: source ./scripts/before_install.sh
@@ -89,10 +87,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - { name: '3.6', target: 'cp36' }
-          - { name: '3.7', target: 'cp37' }
           - { name: '3.8', target: 'cp38' }
           - { name: '3.9', target: 'cp39' }
+          - { name: '3.9', target: 'cp39' }
+          - { name: '3.10', target: 'cp310' }
         architecture: [ aarch64 ]
 
     name: Cross-compile wheels for CPython ${{ matrix.python-version.name }} on ${{ matrix.architecture }}
@@ -103,10 +101,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install and set up CPython 3.9
+      - name: Install and set up CPython 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.x
 
       - name: Install Python dependencies
         shell: bash
@@ -122,12 +120,8 @@ jobs:
       - name: Build wheels
         shell: bash
         env:
-          # Images
-          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64
-          CIBW_MANYLINUX_S390X_IMAGE: quay.io/pypa/manylinux2014_s390x
-
           # Build targeting
-          CIBW_BUILD: ${{ matrix.python-version.target }}-manylinux_${{ matrix.architecture }}
+          CIBW_BUILD: ${{ matrix.python-version.target }}-manylinux_${{ matrix.architecture }} ${{ matrix.python-version.target }}-musllinux_${{ matrix.architecture }}
 
           # Build process
           CIBW_BEFORE_ALL_LINUX: source ./scripts/before_install.sh

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -67,7 +67,7 @@ jobs:
 
           # Build targeting
           CIBW_BUILD: ${{ matrix.target.cibw-build }}
-          CIBW_SKIP: cp2?-* pp*
+          CIBW_SKIP: cp2?-* cp35-* pp*
 
           # Build process
           CIBW_BEFORE_ALL_LINUX: source ./scripts/before_install.sh
@@ -89,7 +89,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - { name: '3.5', target: 'cp35' }
           - { name: '3.6', target: 'cp36' }
           - { name: '3.7', target: 'cp37' }
           - { name: '3.8', target: 'cp38' }
@@ -112,7 +111,7 @@ jobs:
       - name: Install Python dependencies
         shell: bash
         run: |
-          python -m pip install -U pip setuptools wheel "cibuildwheel @ git+https://github.com/asfaltboy/cibuildwheel@support-quemu-on-github"
+          python -m pip install -U pip setuptools wheel cibuildwheel
 
       - name: Set up Qemu
         id: qemu

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -16,15 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - { os: 'windows-latest', python-architecture: 'x86', rust-architecture: 'i686', rust-platform: 'pc-windows-msvc', cibw-build: '*-win32' }
-          - { os: 'windows-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'pc-windows-msvc', cibw-build: '*-win_amd64' }
-          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_i686' }
-          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_x86_64' }
-          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-musl', cibw-build: '*-musllinux_i686' }
-          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', cibw-build: '*-musllinux_x86_64' }
-          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', cibw-build: '*-macosx_x86_64' }
+          - { os: 'windows-latest', python-architecture: 'x86', rust-architecture: 'i686', rust-platform: 'pc-windows-msvc', libc: 'msvc', cibw-build: '*-win32' }
+          - { os: 'windows-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'pc-windows-msvc', libc: 'msvc', cibw-build: '*-win_amd64' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-gnu', libc: 'gnu', cibw-build: '*-manylinux_i686' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', libc: 'gnu', cibw-build: '*-manylinux_x86_64' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', libc: 'musl', cibw-build: '*-musllinux_x86_64' }
+          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_x86_64' }
 
-    name: Build wheels for ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}
+    name: Build ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}/${{ matrix.target.libc }}
 
     steps:
       - name: Clone repository

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -53,6 +53,11 @@ jobs:
         run: |
           rustup default ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
           rustup override set ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
+
+      - name: Install Perl (this is weirdly needed to build OpenSSL)
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.34'
 
       - name: Install Python dependencies
         shell: bash
@@ -96,7 +101,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -1,0 +1,155 @@
+name: Build wheels
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+
+jobs:
+  build-native-distributions:
+    runs-on: ${{ matrix.target.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { os: 'windows-latest', python-architecture: 'x86', rust-architecture: 'i686', rust-platform: 'pc-windows-msvc', cibw-build: '*-win32' }
+          - { os: 'windows-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'pc-windows-msvc', cibw-build: '*-win_amd64' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'i686', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_i686' }
+          - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', cibw-build: '*-manylinux_x86_64' }
+          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', cibw-build: '*-macosx_x86_64' }
+
+    name: Build wheels for ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install and set up CPython 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+          architecture: ${{ matrix.target.python-architecture }}
+
+      - name: Install Rust toolchain with support for ${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
+        uses: actions-rs/toolchain@v1
+        if: matrix.target.os != 'ubuntu-latest'
+        with:
+          profile: minimal
+          target: ${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
+          toolchain: ${{ matrix.target.rust-toolchain || 'stable' }}
+          default: true
+          override: true
+
+      - name: Replace directory override with desired target
+        shell: bash
+        if: matrix.target.os != 'ubuntu-latest'
+        run: |
+          rustup default ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
+          rustup override set ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pip wheel setuptools cibuildwheel
+
+      - name: Build wheels
+        shell: bash
+        env:
+          # Images
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
+
+          # Build targeting
+          CIBW_BUILD: ${{ matrix.target.cibw-build }}
+          CIBW_SKIP: cp2?-* pp*
+
+          # Build process
+          CIBW_BEFORE_ALL_LINUX: source ./scripts/before_install.sh
+          CIBW_BEFORE_BUILD: python -m pip install -U pip -r requirements-dev.txt
+          CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBOPUS_STATIC=1'
+
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheelhouse
+          path: wheelhouse/
+
+  build-cross-distributions:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - { name: '3.5', target: 'cp35' }
+          - { name: '3.6', target: 'cp36' }
+          - { name: '3.7', target: 'cp37' }
+          - { name: '3.8', target: 'cp38' }
+          - { name: '3.9', target: 'cp39' }
+        architecture: [ aarch64 ]
+
+    name: Cross-compile wheels for CPython ${{ matrix.python-version.name }} on ${{ matrix.architecture }}
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install and set up CPython 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pip setuptools wheel "cibuildwheel @ git+https://github.com/russkel/cibuildwheel.git@qemu"
+
+      - name: Build wheels
+        shell: bash
+        env:
+          # Images
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64
+          CIBW_MANYLINUX_S390X_IMAGE: quay.io/pypa/manylinux2014_s390x
+
+          # Build targeting
+          CIBW_BUILD: ${{ matrix.python-version.target }}-manylinux_${{ matrix.architecture }}
+
+          # Build process
+          CIBW_BEFORE_ALL_LINUX: source ./scripts/before_install.sh
+          CIBW_BEFORE_BUILD: python -m pip install -U pip -r requirements-dev.txt
+          CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBOPUS_STATIC=1'
+
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse --use-binfmt
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheelhouse
+          path: wheelhouse/
+
+  upload_pypi:
+    needs: [ build-native-distributions, build-cross-distributions ]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheelhouse
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.pypi_username }}
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -112,7 +112,13 @@ jobs:
       - name: Install Python dependencies
         shell: bash
         run: |
-          python -m pip install -U pip setuptools wheel "cibuildwheel @ git+https://github.com/russkel/cibuildwheel.git@qemu"
+          python -m pip install -U pip setuptools wheel "cibuildwheel @ git+https://github.com/asfaltboy/cibuildwheel@support-quemu-on-github"
+
+      - name: Set up Qemu
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: ${{ matrix.architecture }}
 
       - name: Build wheels
         shell: bash
@@ -130,7 +136,7 @@ jobs:
           CIBW_ENVIRONMENT: 'PATH="$PATH:$HOME/.cargo/bin" LIBOPUS_STATIC=1'
 
         run: |
-          python -m cibuildwheel --output-dir wheelhouse --use-binfmt
+          python -m cibuildwheel --output-dir wheelhouse --arch ${{ matrix.architecture }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v2

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', libc: 'gnu', cibw-build: '*-manylinux_x86_64' }
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', libc: 'musl', cibw-build: '*-musllinux_x86_64' }
           - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_x86_64' }
-          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_arm64' }
+          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'aarch64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_arm64' }
 
     name: Build ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}/${{ matrix.target.libc }}
 
@@ -48,9 +48,9 @@ jobs:
           default: true
           override: true
 
-      - name: Replace directory override with desired target
+      - name: Replace toolchain (rustc, etc) to use with desired target
         shell: bash
-        if: matrix.target.os != 'ubuntu-latest'
+        if: matrix.target.os == 'windows-latest'
         run: |
           rustup default ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}
           rustup override set ${{ matrix.target.rust-toolchain || 'stable' }}-${{ matrix.target.rust-architecture }}-${{ matrix.target.rust-platform }}

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -22,7 +22,7 @@ jobs:
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', libc: 'gnu', cibw-build: '*-manylinux_x86_64' }
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', libc: 'musl', cibw-build: '*-musllinux_x86_64' }
           - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_x86_64' }
-          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'aarch64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_arm64' }
+          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_arm64' }
 
     name: Build ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}/${{ matrix.target.libc }}
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build wheels
         env:
           # Build targeting
+          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_BUILD: ${{ matrix.target.cibw-build }}
           CIBW_SKIP: cp2?-* cp35-* cp36-* cp37-* pp*
 

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -22,6 +22,7 @@ jobs:
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-gnu', libc: 'gnu', cibw-build: '*-manylinux_x86_64' }
           - { os: 'ubuntu-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'unknown-linux-musl', libc: 'musl', cibw-build: '*-musllinux_x86_64' }
           - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'x86_64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_x86_64' }
+          - { os: 'macos-latest', python-architecture: 'x64', rust-architecture: 'aarch64', rust-platform: 'apple-darwin', libc: 'darwin', cibw-build: '*-macosx_arm64' }
 
     name: Build ${{ matrix.target.rust-architecture }} on ${{ matrix.target.os }}/${{ matrix.target.libc }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 *.pcm
 *.log
 *.pyd
+build/
+dist/
+wheelhouse/
 
 # Ignore top level py files except setup.py
 /*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,20 @@ jobs:
 
 env:
   global:
-    - CIBW_BEFORE_ALL_LINUX="source ./scripts/before_install.sh"
-    - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin" CARGO_TARGET_DIR="$TRAVIS_BUILD_DIR/target"'
+    # Images
+    - CIBW_MANYLINUX_AARCH64_IMAGE="quay.io/pypa/manylinux2014_aarch64"
+    - CIBW_MANYLINUX_I686_IMAGE="quay.io/pypa/manylinux2014_i686"
+    - CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+
+    # Build targeting
     - CIBW_SKIP="cp27-* cp34-* pp*"
+
+    # Build process
+    - CIBW_BEFORE_ALL_LINUX="source ./scripts/before_install.sh"
+    - CIBW_BEFORE_BUILD="python -m pip install -U pip -r requirements-dev.txt"
+    - CIBW_ENVIRONMENT='PATH="$PATH:$HOME/.cargo/bin" CARGO_TARGET_DIR="$TRAVIS_BUILD_DIR/target"'
+
+    # Twine
     - TWINE_USERNAME="__token__"
 
 before_install:
@@ -33,8 +44,9 @@ before_install:
 
 install:
     - |
-      python3 -m pip install --upgrade pip wheel setuptools setuptools-rust==0.11.3
-      python3 -m pip install --upgrade pip cibuildwheel
+      python3 -m pip install -U pip setuptools wheel
+      python3 -m pip install -U cibuildwheel
+      python3 -m pip install -U -r requirements-dev.txt
 
 script:
     - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam-channel = { version = "0.4" }
 xsalsa20poly1305 = { version = "0.4", features = ["heapless"] }
 rand = { version = "0.7" }
 audiopus = { version = "0.2" }
+openssl = { version = "^0.10.38", features = ["vendored"] }
 
 [lib]
 name = "_native_voice"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include Cargo.toml
+recursive-include src *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   TWINE_USERNAME: __token__
   matrix:
     - RUST_TARGET: x86_64-pc-windows-msvc
-      CIBW_SKIP: "*win32* cp27-* cp33-* cp34-* pp*"
+      CIBW_SKIP: "*win32* cp27-* cp33-* cp34-* cp35-* pp*"
       CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust
 
     - RUST_TARGET: i686-pc-windows-msvc
-      CIBW_SKIP: "*win_amd64* cp27-* cp33-* cp34-* pp*"
+      CIBW_SKIP: "*win_amd64* cp27-* cp33-* cp34-* cp35-* pp*"
       CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ environment:
   matrix:
     - RUST_TARGET: x86_64-pc-windows-msvc
       CIBW_SKIP: "*win32* cp27-* cp33-* cp34-* pp*"
-      CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust==0.11.3
+      CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust
 
     - RUST_TARGET: i686-pc-windows-msvc
       CIBW_SKIP: "*win_amd64* cp27-* cp33-* cp34-* pp*"
-      CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust==0.11.3
+      CIBW_BEFORE_BUILD: C:\Python36\python.exe -m pip install setuptools setuptools-rust
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
@@ -15,8 +15,8 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV
-  - C:\Python36\python.exe -m pip install -U pip
-  - C:\Python36\python.exe -m pip install wheel cibuildwheel setuptools setuptools-rust==0.11.3
+  - C:\Python36\python.exe -m pip install -U pip cibuildwheel
+  - C:\Python36\python.exe -m pip install -U -r requirements-dev.txt
 
 build_script:
   - C:\Python36\python.exe -m cibuildwheel --output-dir wheelhouse

--- a/discord/ext/native_voice/__init__.py
+++ b/discord/ext/native_voice/__init__.py
@@ -30,7 +30,7 @@ class VoiceClient(discord.VoiceProtocol):
             if channel_id is None:
                 return await self.disconnect()
 
-            self.channel = channel_id and self.guild.get_channel(int(chananel_id))
+            self.channel = channel_id and self.guild.get_channel(int(channel_id))
         else:
             self._voice_state_complete.set()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools
-setuptools-rust>=0.12,<0.13
+setuptools-rust~=1.2
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools
-setuptools-rust>=0.11.5,<0.12
+setuptools-rust>=0.12,<0.13
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools
-setuptools-rust==0.11.1
+setuptools-rust>=0.11.5,<0.12
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Rapptz/discord.py@voice-protocol
+discord.py @ git+https://github.com/Rapptz/discord.py@master

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,5 +1,6 @@
 curl --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
 
 if command -v yum; then
-    yum install -y openssl-devel opus
+    # We must set this option otherwise yum will just continue silently if it can't install one of these
+    yum --setopt=skip_missing_names_on_install=False install -y openssl-devel opus
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,4 @@ classifiers =
 [options]
 packages = discord.ext.native_voice
 zip_safe = False
-setup_requires = setuptools-rust>=0.11.5,<0.12; wheel
+setup_requires = setuptools-rust>=0.12,<0.13; wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = discord-ext-native-voice
+license = MIT or Apache-2
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    License :: OSI Approved :: Apache 2.0
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Programming Language :: Python
+    Programming Language :: Rust
+    Operating System :: POSIX
+    Operating System :: Windows
+    Operating System :: MacOS
+
+[options]
+packages = discord.ext.native_voice
+zip_safe = False
+setup_requires = setuptools-rust>=0.11.5,<0.12; wheel

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import sys
+
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
@@ -30,7 +30,7 @@ setup(
     
     install_requires=install_requires,
     setup_requires=setup_requires,
-    python_requires='>=3.5.3',
+    python_requires='>=3.6',
 
     classifiers=[
         "License :: OSI Approved :: Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,37 @@
 #!/usr/bin/env python
 import sys
 from setuptools import setup
-from setuptools_rust import RustExtension
+from setuptools_rust import Binding, RustExtension
 
-setup_requires = [
-    'setuptools-rust>=0.11.1,<0.12',
-    'wheel',
-]
+
+with open('requirements.txt', 'r', encoding='utf-8') as f:
+    install_requires = f.read().splitlines()
+
+with open('requirements-dev.txt', 'r', encoding='utf-8') as f:
+    setup_requires = f.read().splitlines()
+
+with open('README.md', 'r', encoding='utf-8') as f:
+    readme = f.read()
+
 
 setup(
     name='discord-ext-native-voice',
+    author='Rapptz',
+    url='https://github.com/Rapptz/discord-ext-native-voice',
+
     version='0.1.0',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+
+    packages=['discord.ext.native_voice'],
+    include_package_data=True,
+    zip_safe=False,
+    rust_extensions=[RustExtension('discord.ext.native_voice._native_voice', binding=Binding.PyO3)],
+    
+    install_requires=install_requires,
+    setup_requires=setup_requires,
+    python_requires='>=3.5.3',
+
     classifiers=[
         "License :: OSI Approved :: Apache 2.0",
         "Development Status :: 3 - Alpha",
@@ -21,10 +42,4 @@ setup(
         "Operating System :: Windows",
         "Operating System :: MacOS",
     ],
-    packages=['discord.ext.native_voice'],
-    rust_extensions=[RustExtension('discord.ext.native_voice._native_voice')],
-    install_requires=[],
-    setup_requires=setup_requires,
-    include_package_data=True,
-    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     
     install_requires=install_requires,
     setup_requires=setup_requires,
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 
     classifiers=[
         "License :: OSI Approved :: Apache 2.0",


### PR DESCRIPTION
This PR adds in GitHub Actions workflows for building wheels for this extension using `cibuildwheel`.

It builds wheels for CPython 3.8 through 3.10 for these targets:
- 64-bit manylinux2014 (`x86_64`), which should catch the majority of GNU Linux installations;
- 32-bit manylinux2014 (`i686`);
- 64-bit musllinux1_1 (`x86_64`), which covers Alpine;
- ARMv8 manylinux2014 (`aarch64`), which covers GNU-likes (Debian, Ubuntu, Arch) on Raspberry Pis, using Qemu support in cibuildwheel;
- ARMv8 musllinux1_1 (`aarch64`), which covers Alpine on Raspberry Pis, using Qemu support in cibuildwheel;
- 64-bit Windows (`win_amd64`);
- 32-bit Windows (`win32`);
- 64-bit macOS (`x86_64`)

It also fixes the other CI/CD workflows that have broken because of regressions in other packages/environments, as well as some changes and fixes that improve the installability standard of the package as a whole.
