### PR TITLE
bump setuptools-rust version to 0.12.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 setuptools
-setuptools-rust==0.11.1
+setuptools-rust==0.12.1
 wheel

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools_rust import RustExtension
 
 setup_requires = [
-    'setuptools-rust>=0.11.1,<0.12',
+    'setuptools-rust==0.12.1',
     'wheel',
 ]
 


### PR DESCRIPTION
Trying to install this package resulted in this error message from pip: `ERROR: Some build dependencies for file:///mnt/c/Users/xtk42/discord-ext-native-voice conflict with the backend dependencies: setuptools-rust==0.12.1 is incompatible with setuptools-rust<0.12,>=0.11.1.` 
This PR fixes this by changing the required setuptools-rust version to 0.12.1.